### PR TITLE
Add eio-trace render output.svg

### DIFF
--- a/gtk/dune
+++ b/gtk/dune
@@ -1,4 +1,4 @@
 (executable
  (public_name eio-trace-gtk)
  (name main)
- (libraries eio_trace lablgtk3 cmdliner))
+ (libraries eio_trace lablgtk3))

--- a/gtk/main.ml
+++ b/gtk/main.ml
@@ -1,22 +1,38 @@
 open Eio_trace
 
-let main tracefile =
+let load tracefile =
   let ch = open_in_bin tracefile in
   let len = in_channel_length ch in
   let data = really_input_string ch len in
   close_in ch;
   let trace = Trace.create data in
-  Gtk_ui.create (Model.of_trace trace);
+  Model.of_trace trace
+
+let show tracefile =
+  Gtk_ui.create (load tracefile);
   GMain.main ()
 
-open Cmdliner
+let render ~output tracefile =
+  let m = load (tracefile) in
+  let v =
+    View.of_model m
+      ~width:1280.
+      ~height:((float m.height +. 0.5) *. View.pixels_per_row +. 2. *. View.v_margin)
+  in
+  View.zoom_to_fit v;
+  let surface = Cairo.SVG.create
+    output
+    ~w:v.width
+    ~h:v.height
+  in
+  let cr = Cairo.create surface in
+  Cairo.rectangle cr 0.0 0.0 ~w:v.width ~h:v.height;
+  Cairo.clip cr;
+  Render_cairo.render v cr;
+  Cairo.Surface.finish surface
 
-let tracefile =
-  let doc = "The path of the trace file." in
-  Arg.(required @@ pos 0 (some string) None @@ info [] ~doc)
-
-let cmd =
-  let t = Term.(const main $ tracefile) in
-  Cmd.v (Cmd.info "eio-trace-gtk") t
-
-let () = exit (Cmd.eval cmd)
+let () =
+  match Sys.argv with
+  | [| _; "show"; tracefile |] -> show tracefile
+  | [| _; "render-svg"; tracefile; output |] -> render tracefile ~output
+  | _ -> failwith "Invalid arguments (eio-trace-gtk should be run via eio-trace)"

--- a/gtk/render_cairo.ml
+++ b/gtk/render_cairo.ml
@@ -1,0 +1,26 @@
+module Canvas = struct
+  include Cairo
+
+  let move_to cr ~x ~y = move_to cr x y
+  let line_to cr ~x ~y = line_to cr x y
+  let rectangle cr ~x ~y ~w ~h = rectangle cr x y ~w ~h
+
+  let paint_text cr ?clip_area ~x ~y msg =
+    match clip_area with
+    | None ->
+      move_to cr ~x ~y;
+      show_text cr msg
+    | Some (w, h) ->
+      save cr;
+      rectangle cr ~x ~y:0.0 ~w ~h;
+      clip cr;
+      move_to cr ~x ~y;
+      show_text cr msg;
+      restore cr
+
+  let set_source_rgb cr ~r ~g ~b = set_source_rgb cr r g b
+  let set_source_alpha cr ~r ~g ~b a = set_source_rgba cr r g b a
+  let set_source_rgba cr ~r ~g ~b ~a = set_source_rgba cr r g b a
+end
+
+include Eio_trace.Render.Make(Canvas)

--- a/lib/model.ml
+++ b/lib/model.ml
@@ -114,7 +114,7 @@ let layout root =
     Fmt.epr "%d is at %d+%d@." i.id y i.height;
   in
   visit root ~y:0;
-  !max_y
+  !max_y + 1
 
 let of_trace (trace : Trace.t) =
   let start_time, root = Option.get trace.root in

--- a/lib/view.ml
+++ b/lib/view.ml
@@ -35,9 +35,17 @@ let grid t x =
   let grid_start_x = (starting_grid_line *. grid_step_x) -. t.start_time *. t.pixels_per_ns in
   grid_step *. 1e-9, grid_start_x, grid_step_x
 
-let zoom t delta =
-  t.zoom <- clamp (t.zoom +. delta) ~min:(-.15.) ~max:2.5;
+let zoom_to t z =
+  t.zoom <- clamp z ~min:(-.15.) ~max:2.5;
   t.pixels_per_ns <- 10. ** t.zoom
+
+let zoom t delta =
+  zoom_to t (t.zoom +. delta)
+
+let zoom_to_fit t =
+  let ppns = (t.width -. 2. *. h_margin) /. t.model.duration in
+  zoom_to t (log ppns /. log 10.);
+  t.start_time <- -. timespan_of_width t h_margin
 
 let max_x_scroll t =
   width_of_timespan t t.model.duration +. h_margin
@@ -67,5 +75,4 @@ let set_size t width height =
 let of_model model ~width ~height =
   let t = { model; width; height; start_time = 0.; scroll_y = -. v_margin; pixels_per_ns = 0.0; zoom = -3.0 } in
   zoom t 0.0;
-  t.start_time <- -. timespan_of_width t h_margin;
   t


### PR DESCRIPTION
Also, when using GTK, zoom to fit the trace at start-up.