### PR TITLE
Improve layout

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -12,4 +12,5 @@
   (ocaml (>= 5.1.0))
   (eio_main (>= 0.13))
   (cmdliner (>= 1.2.0))
-  (lablgtk3 (>= 3.1.3))))
+  (lablgtk3 (>= 3.1.3))
+  (crowbar (and (>= 0.2.1) :with-test))))

--- a/eio-trace.opam
+++ b/eio-trace.opam
@@ -11,6 +11,7 @@ depends: [
   "eio_main" {>= "0.13"}
   "cmdliner" {>= "1.2.0"}
   "lablgtk3" {>= "3.1.3"}
+  "crowbar" {>= "0.2.1" & with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/lib/itv.ml
+++ b/lib/itv.ml
@@ -1,0 +1,73 @@
+(* An (Augmented) Interval Tree:
+  https://en.wikipedia.org/wiki/Interval_tree#Augmented_tree *)
+
+type 'a interval = {
+  start : float;
+  stop : float;
+  value : 'a;
+}
+
+let compare_start a b = compare a.start b.start
+
+type 'a tree =
+  | Empty
+  | Node of {
+      v : 'a interval;
+      left : 'a tree;     (* No interval in the left sub-tree starts after v starts. *)
+      right : 'a tree;
+      mutable subtree_stop : float; (* The max end_time in this sub-tree *)
+    }
+
+let pp_interval f { start; stop; value = _ } =
+  Fmt.pf f "[%g, %g)" start stop
+
+let rec dump f = function
+  | Empty -> Fmt.string f "."
+  | Node { left; right; subtree_stop; v } ->
+    Fmt.pf f "@[<v2>%a subtree_stop = %g@,left = %a@,right = %a@]"
+      pp_interval v
+      subtree_stop
+      dump left
+      dump right
+      
+let max_stop n acc =
+  match n with
+  | Empty -> acc
+  | Node n -> max acc n.subtree_stop
+
+let rec tree_of_slice arr i len =
+  if len = 0 then Empty
+  else (
+    let left_len = len / 2 in
+    let mid = i + left_len in
+    let v = arr.(mid) in
+    let left = tree_of_slice arr i left_len in
+    let right = tree_of_slice arr (mid + 1) (len - left_len  - 1) in
+    let subtree_stop =
+      v.stop
+      |> max_stop left
+      |> max_stop right
+    in
+    Node { v; left; right; subtree_stop }
+  )
+
+let create spans =
+  let spans = Array.of_list spans in
+  Array.sort compare_start spans;
+  tree_of_slice spans 0 (Array.length spans)
+
+let overlaps i start stop =
+  start < i.stop && stop > i.start
+
+let rec iter_overlaps f start stop = function
+  | Empty -> ()
+  | Node { v; left; right; subtree_stop } ->
+    if subtree_stop > start then (
+      (* Search the left sub-tree. *)
+      iter_overlaps f start stop left;
+      (* Check this node. *)
+      if overlaps v start stop then f v.value;
+      (* Search the right sub-tree. *)
+      if v.start < stop then
+        iter_overlaps f start stop right
+    )

--- a/lib/model.ml
+++ b/lib/model.ml
@@ -1,5 +1,7 @@
 type timestamp = float    (* ns since start_time *)
 
+module Ids = Map.Make(Int)
+
 module Spans : sig
   type 'a t
   (* The history of a stack of spans of type 'a *)
@@ -43,7 +45,7 @@ end
 type event =
   | Log of string
   | Create_cc of string * item
-  | Add_fiber of item
+  | Add_fiber of { parent : int; child : item }
 and item = {
   id : int;
   name : string option;
@@ -56,16 +58,19 @@ and item = {
 }
 
 type t = {
+  items : item Ids.t;
   start_time : int64;
   duration : float;
   root : item;
   height : int;
 }
 
+let get t id = Ids.find_opt id t.items
+
 let map_event f : Trace.event -> event = function
   | Log x -> Log x
   | Create_cc (ty, x) -> Create_cc (ty, f x)
-  | Add_fiber x -> Add_fiber (f x)
+  | Add_fiber { parent; child } -> Add_fiber { parent; child = f child }
 
 let dummy_event = 0., Log ""
 
@@ -109,10 +114,10 @@ let layout ~duration root =
     i.events |> Array.iter (fun (ts, e) ->
         match e with
         | Log _ | Create_cc _ -> ()
-        | Add_fiber f ->
-          Fmt.epr "%d creates fiber %d@." i.id f.id;
-          let stop = Option.value f.end_time ~default:duration in
-          intervals := { Itv.value = f; start = ts; stop } :: !intervals;
+        | Add_fiber { parent; child } ->
+          Fmt.epr "%d gets fiber %d, created by %d@." i.id child.id parent;
+          let stop = Option.value child.end_time ~default:duration in
+          intervals := { Itv.value = child; start = ts; stop } :: !intervals;
       );
     let intervals = List.rev !intervals in
     let itv = Itv.create intervals in
@@ -142,11 +147,13 @@ let of_trace (trace : Trace.t) =
     duration := max !duration f;
     f
   in
+  let items = ref Ids.empty in
   let rec import (item : Trace.item) =
     let events = import_events item.events in
     let activations = import_activations item.activations in
     let end_time = Option.map time item.end_time in
     let x = { id = item.id; name = item.name; end_time; events; activations; y = 0; height = 0; end_cc_label = None } in
+    items := Ids.add x.id x !items;
     x
   and import_activations xs =
     let s = Spans.create () in
@@ -174,8 +181,9 @@ let of_trace (trace : Trace.t) =
     events |> List.rev |> List.map (fun (ts, x) -> (time ts, map_event import x)) |> Array.of_list
   in
   let root = import root in
+  let items = !items in
   let duration = !duration in
   let height = layout root ~duration in
-  { start_time; duration; root; height }
+  { start_time; duration; root; height; items }
 
 let start_time t = t.start_time

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(test
+  (name test)
+  (libraries crowbar eio-trace))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,28 @@
+module Itv = Eio_trace.Itv
+
+let span = Crowbar.(map [uint8; uint8]) (fun start len -> (float start, float (start + len)))
+
+let itv_span (start, stop) =
+  { Itv.start; stop; value = ref false }
+
+let mark x = x := true
+
+let pp_span f (x : _ Itv.interval) =
+  Fmt.pf f "[%g, %g)" x.start x.stop
+
+let test_ivt spans (start, stop) =
+  let spans = List.map itv_span spans in
+  let t = Itv.create spans in
+  Itv.iter_overlaps mark start stop t;
+  spans |> List.iter (fun span ->
+      let overlaps = Itv.overlaps span start stop in
+      let reported = !(span.value) in
+      if overlaps && not reported then (
+        Crowbar.failf "Span %a overlaps [%g, %g) but wasn't returned!@.%a" pp_span span start stop Itv.dump t
+      ) else if reported && not overlaps then (
+        Crowbar.failf "Span %a doesn't overlap [%g, %g) but was returned!@.%a" pp_span span start stop Itv.dump t
+      )
+    )
+
+let () =
+  Crowbar.(add_test ~name:"ivt" [list span; span] test_ivt)


### PR DESCRIPTION
Before, each new fiber within a CC was placed below the previous one. A series of fibers in serial would lead to a staircase, wasting space.

Now it uses an interval tree to find other things in the same time period and places it below the lowest of those.

Also, show the fiber creation link from the parent fiber to the child. Before, it was shown from the owning CC's fiber, but that isn't always the parent.

Before:
![wayland-old](https://github.com/ocaml-multicore/eio-trace/assets/554131/ed968e51-7e46-4f11-b556-a62270bbc8c3)

After:
![wayland-new](https://github.com/ocaml-multicore/eio-trace/assets/554131/b8ced99c-8971-4eea-9537-31b1f8fe015e)
