### PR TITLE
Add eio-trace render PNG output

### DIFF
--- a/lib/view.ml
+++ b/lib/view.ml
@@ -42,9 +42,9 @@ let zoom_to t z =
 let zoom t delta =
   zoom_to t (t.zoom +. delta)
 
-let zoom_to_fit ?(start_time=0.0) ?(duration=infinity) t =
+let zoom_to_fit ?(start_time=0.0) ?duration t =
   let start_time = min start_time t.model.duration in
-  let duration = min duration (t.model.duration -. start_time) in
+  let duration = Option.value duration ~default:(t.model.duration -. start_time) in
   let ppns = (t.width -. 2. *. h_margin) /. duration in
   zoom_to t (log ppns /. log 10.);
   t.start_time <- start_time -. timespan_of_width t h_margin

--- a/src/main.ml
+++ b/src/main.ml
@@ -82,11 +82,14 @@ let record ~fs ~proc_mgr freq tracefile args =
   Record.run ~fs ~proc_mgr ~freq ~tracefile args
 
 let render tracefile output start_time duration =
-  if Filename.check_suffix output ".svg" then (
+  match Filename.extension output with
+  | "" -> Fmt.error "No extension on %S; can't determine format" output
+  | ".svg"
+  | ".png" as format ->
     let start_time = Option.value start_time ~default:0.0 |> string_of_float in
     let duration = Option.map string_of_float duration |> Option.value ~default:"" in
-    exec_gtk ["render-svg"; tracefile; output; start_time; duration]
-  ) else
+    exec_gtk ["render-svg"; tracefile; format; output; start_time; duration]
+  | _ ->
     Fmt.error "Unknown file extension in %S (should end in e.g. '.svg')" output
 
 let cmd env =


### PR DESCRIPTION
Also, don't clamp the `--duration` value. When comparing traces, it's useful to use the same scale even if one of them then doesn't fill the page.