### PR TITLE
Improve ring events

### DIFF
--- a/gtk/main.ml
+++ b/gtk/main.ml
@@ -22,14 +22,14 @@ let show ?args tracefile =
   in
   Gtk_ui.create ~title (load tracefile)
 
-let render ~output ~start_time ~duration ~format tracefile =
+let render ~output ~start_time ?duration ~format tracefile =
   let l = load (tracefile) in
   let v =
     View.of_layout l
       ~width:1280.
       ~height:((float l.height +. 0.5) *. View.pixels_per_row +. 2. *. View.v_margin)
   in
-  View.zoom_to_fit v ~start_time ~duration;
+  View.zoom_to_fit v ~start_time ?duration;
   let create =
     match format with
     | `Svg -> Cairo.SVG.create output
@@ -62,13 +62,13 @@ let () =
   | [ _; "render-svg"; tracefile; format; output; start_time; duration ] ->
     let duration =
       match duration with
-      | "" -> infinity
-      | x -> float_of_string x *. 1e9
+      | "" -> None
+      | x -> Some (float_of_string x *. 1e9)
     in
     render tracefile
       ~output
       ~start_time:(float_of_string start_time *. 1e9)
-      ~duration
+      ?duration
       ~format:(format_of_string format)
   | args ->
     Fmt.failwith "Invalid arguments (eio-trace-gtk should be run via eio-trace)@.(got %a)"

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -151,7 +151,7 @@ let layout ~duration (ring : Ring.t) =
   in
   let visit_domain (_ts, (i : item)) =
     i.y <- ring.y;
-    i.height <- 0;
+    i.height <- 1;
     i.end_cc_label <- None;
     i.events |> Array.iter (fun (_ts, e) ->
         match e with

--- a/lib/render.ml
+++ b/lib/render.ml
@@ -215,7 +215,7 @@ module Make (C : CANVAS) = struct
     let h = float ring.height *. Style.line_spacing in
     let prev_stack = ref [] in
     let event = ref (0.0, []) in
-    C.set_font_size cr Style.small_text;
+    C.set_font_size cr Style.big_text;
     ring |> iter_gc_spans v (fun event' ->
         let t0, stack = !event in
         event := event';
@@ -226,7 +226,7 @@ module Make (C : CANVAS) = struct
         begin match stack with
           | [] -> ()
           | op :: p ->
-            let g = min 1.0 (0.1 *. float (List.length stack)) in
+            let g = 1.0 -. min 1.0 (0.1 *. float (List.length stack)) in
             C.set_source_rgba cr ~r:g ~g:g ~b:(g /. 2.) ~a:0.9;
             C.rectangle cr ~x:x0 ~y ~w ~h;
             C.fill cr;
@@ -234,7 +234,7 @@ module Make (C : CANVAS) = struct
               let clip_area = (w -. 0.2, v.height) in
               if g < 0.5 then C.set_source_rgb cr ~r:1.0 ~g:1.0 ~b:1.0
               else C.set_source_rgb cr ~r:0.0 ~g:0.0 ~b:0.0;
-              C.paint_text cr ~x:(x0 +. 2.) ~y:(y +. 8.) op
+              C.paint_text cr ~x:(x0 +. 2.) ~y:(y +. 12.) op
                 ~clip_area
             )
         end;

--- a/src/record.ml
+++ b/src/record.ml
@@ -122,7 +122,8 @@ let callbacks t =
          Write.user_object t.fxt ~name ~thread (Int64.of_int id)
        | `Suspend_fiber op ->
          Option.iter (fun f -> f.op <- Some op) current_fiber;
-         Write.duration_begin t.fxt ~thread ~ts ~name:op ~category:"eio.suspend"
+         Write.duration_begin t.fxt ~thread ~ts ~name:op ~category:"eio.suspend";
+         ring.current_fiber <- None
        | `Enter_span op ->
          Write.duration_begin t.fxt ~thread ~name:op ~category:"eio.span" ~ts
        | `Exit_span ->


### PR DESCRIPTION
- Show spans for ring events. Before, a span when no fiber was running was shown on the previous
fiber. Now, it's rendered as a ring event.

- Put ring events on their own row. Otherwise, they overlap with events on the root fiber.

- Start nested ring events with a light background getting darker, as this is less distracting.

Example:
![both](https://github.com/ocaml-multicore/eio-trace/assets/554131/b3e16de4-9106-4807-adda-c893f251eaa5)
