### PR TITLE
Improve render and dump CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ dune exec -- eio-trace show trace.fxt
 To convert a trace to SVG format:
 
 ```
-dune exec -- eio-trace render -f trace.fxt trace.svg
+dune exec -- eio-trace render trace.fxt
 ```
+
+You can also use `--format=png` for PNG output.
 
 ## Reading traces
 

--- a/src/dump.ml
+++ b/src/dump.ml
@@ -1,7 +1,9 @@
 module Read = Fxt.Read
 
-let main out tracefile =
-  Eio.Path.with_open_in tracefile @@
-  Eio.Buf_read.parse_exn ~max_size:max_int @@ fun r ->
-  Fmt.pf out "@[<v>%a@]@." (Fmt.seq Read.pp_record) (Read.records r);
+let main out tracefiles =
+  tracefiles |> List.iter (fun tracefile ->
+      Eio.Path.with_open_in tracefile @@
+      Eio.Buf_read.parse_exn ~max_size:max_int @@ fun r ->
+      Fmt.pf out "@[<v>%a@]@." (Fmt.seq Read.pp_record) (Read.records r);
+    );
   Ok ()


### PR DESCRIPTION
`eio-trace render` and `eio-trace dump` now take a list of trace files rather than the name of the output. This works better with tab-completion and is consistent with how the `show` sub-command works.