### PR TITLE
Add --cpu option

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -11,6 +11,7 @@
  (synopsis "Trace visualisation for Eio programs")
  (depends
   (ocaml (>= 5.1.0))
+  processor
   (eio_main (>= 0.14))
   (cmdliner (>= 1.2.0))
   (lablgtk3 (>= 3.1.4))

--- a/eio-trace.opam
+++ b/eio-trace.opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio-trace/issues"
 depends: [
   "dune" {>= "3.11"}
   "ocaml" {>= "5.1.0"}
+  "processor"
   "eio_main" {>= "0.14"}
   "cmdliner" {>= "1.2.0"}
   "lablgtk3" {>= "3.1.4"}

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (executable
   (public_name eio-trace)
   (name main)
-  (libraries eio_main eio_trace cmdliner fxt))
+  (libraries eio_main eio_trace cmdliner fxt processor))

--- a/src/record.mli
+++ b/src/record.mli
@@ -1,8 +1,15 @@
+type config = {
+  freq : float;
+  cpu : int option;
+  child_args : string list;
+}
+
 val run :
   ?ui : (string -> (unit, string) result) ->
   ?tracefile:_ Eio.Path.t ->
   proc_mgr:_ Eio.Process.mgr ->
   fs:_ Eio.Path.t ->
-  freq:float ->
-  string list ->
+  config ->
   (unit, string) result
+
+val cmdliner : config Cmdliner.Term.t


### PR DESCRIPTION
Useful to avoid running eio-trace on the same CPU as the program being traced.