### PR TITLE
Fix ring height calculation (again)

### DIFF
--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -168,7 +168,7 @@ let rec make_y_absolute i parent =
     )
 
 let layout_ring ~duration (ring : Ring.t) =
-  let max_y = ref 1 in
+  ring.height <- 1;
   let visit_domain root =
     root.Ring.cc |> Option.iter @@ fun (_ts, (i : item)) ->
     i.y <- 1;
@@ -184,11 +184,10 @@ let layout_ring ~duration (ring : Ring.t) =
             i.end_cc_label <- child.end_cc_label;
           );
       );
+    ring.height <- max ring.height (i.height + i.y);
     make_y_absolute i ring.y;
-    max_y := max !max_y (i.height - 1);
   in
-  List.iter visit_domain ring.roots;
-  ring.height <- !max_y + 1
+  List.iter visit_domain ring.roots
 
 let of_trace (trace : Trace.t) =
   let start_time = trace.start_time in


### PR DESCRIPTION
556f80a8 fixed it for rings without fibers but broke it for ones with them.

v0.2 was confused because `max_y` was set to 1 initially (a relative y) but then updated to an absolute y when positioning fibers. If there were no fibers, it was therefore left as 1.

v0.3 incorrectly fixed this by ignoring the y-position of the root fiber completely. That meant that max-y was always relative (good), but the root fiber's y position is actually 1, not 0.

In this commit, we just track the ring height and forget about `max_y`.