### PR TITLE
Fix display of fibers ending before a suspend

### DIFF
--- a/lib/trace.ml
+++ b/lib/trace.ml
@@ -99,7 +99,9 @@ let add_activation item ts x =
 
 let set_fiber t ring ts id =
   let d = get_ring t ring in
-  current_fiber t ring |> Option.iter (fun old -> add_activation old ts `Pause);
+  current_fiber t ring |> Option.iter (fun old ->
+      if old.end_time = None then add_activation old ts `Pause
+    );
   d.current_fiber <- Some id;
   let f = get t id in
   add_activation f ts (`Fiber id)


### PR DESCRIPTION
When switching to a new fiber, we record a pause event on the old one. If the old fiber had already ended, this had the effect of extending its lifetime to the time of the switch. Normally this doesn't matter because we switch to the next fiber immediately, but it's a problem if there is no runnable thread and the domain sleeps. Then the fiber appears to remain until the domain is resumed.